### PR TITLE
Make Schedule Display Clearer

### DIFF
--- a/index.html
+++ b/index.html
@@ -187,7 +187,7 @@
 		      <div id="table" class="col-md-8 ml-3" style="background-color:#fef8c0;">
 		        <div class=" row no-gutters">
 	              	<div>
-						<div id="content" class="card my-auto card1" style="height:222px;width:50%;top:18px;justify-content: flex-start;">
+						<div id="content" class="card my-auto card1 col-6" style="height:222px;top:18px;justify-content: flex-start;z-index: 2">
 							<div class="card-text">
 								<h5 class='card-title'>Check in</h5>
 								<h6 class='card-subtitle small'>
@@ -195,7 +195,7 @@
 								</h6>
 							</div>
 						</div>
-						<div id="content" class="card my-auto card2" style="/*height:19px;*/width:50%;top:75px;">
+						<div id="content" class="card my-auto card2 col-6" style="/*height:19px;*/top:75px;z-index: 3">
 							<div class="card-text">
 								<h5 class='card-title'>Team Formation</h5>
 								<h6 class='card-subtitle small'>
@@ -203,7 +203,7 @@
 								</h6>
 							</div>
 						</div>
-						<div id="content" class="offset-6 card my-auto card3" style="height:205px;width:50%;top:93px;">
+						<div id="content" class="offset-5 card my-auto card3 col-7" style="height:205px;top:93px;">
 							<div class="card-text">
 								<h5 class='card-title'>Partnership Fair</h5>
 								<h6 class='card-subtitle small'>
@@ -211,7 +211,7 @@
 								</h6>
 							</div>
 						</div>
-						<div id="content" class="offset-6 card my-auto card3" style="/*height:19px;*/width:50%;top:54px;">
+						<div id="content" class="offset-5 card my-auto card3 col-7" style="/*height:19px;*/top:54px;">
 							<div class="card-text">
 								<h5 class='card-title'>Opening Ceremony</h5>
 								<h6 class='card-subtitle small'>
@@ -219,7 +219,7 @@
 								</h6>
 							</div>
 						</div>
-						<div id="content" class=" card my-auto card2" style="height:74px;width:50%;top:148px;">
+						<div id="content" class=" card my-auto card2 col-6" style="height:74px;top:148px;z-index: 3">
 							<div class="card-text">
 								<h5 class='card-title'>Lunch</h5>
 								<h6 class='card-subtitle small'>
@@ -227,7 +227,7 @@
 								</h6>
 							</div>
 						</div>
-						<div id="content" class="offset-6 card my-auto card3" style="/*height:37px;*/width:50%;top:296px;">
+						<div id="content" class="offset-5 card my-auto card3 col-7" style="/*height:37px;*/top:296px;">
 							<div class="card-text">
 								<h5 class='card-title'>Lightning Talks</h5>
 								<h6 class='card-subtitle small'>
@@ -235,7 +235,7 @@
 								</h6>
 							</div>
 						</div>
-						<div id="content" class="card my-auto card1" style="height:74px;width:50%;top:370px;">
+						<div id="content" class="card my-auto card1 col-6" style="height:74px;top:370px;z-index: 3">
 							<div class="card-text">
 								<h5 class='card-title'>Dinner</h5>
 								<h6 class='card-subtitle small'>
@@ -274,7 +274,7 @@
 		      <div id="table2" class="col-md-8 ml-3" style="background-color:#fef8c0;">
 		        <div class=" row no-gutters">
 	              	<div>
-						<div id="content" class="card my-auto card1" style="width:50%;top:18px;">
+						<div id="content" class="card my-auto card1 col-6" style="top:18px;">
 							<div class="card-text">
 								<h5 class='card-title'>Midnight Snack</h5>
 								<h6 class='card-subtitle small'>
@@ -282,7 +282,7 @@
 								</h6>
 							</div>
 						</div>
-						<div id="content" class="offset-6 card my-auto card3" style="height:242px;width:50%;top:92px;">
+						<div id="content" class="offset-5 card my-auto card3 col-7" style="height:242px;top:92px;">
 							<div class="card-text">
 								<h5 class='card-title'>Sleep?</h5>
 								<h6 class='card-subtitle small'>
@@ -290,7 +290,7 @@
 								</h6>
 							</div>
 						</div>
-						<div id="content" class="card my-auto card2" style="height:92px;width:50%;top:277px;">
+						<div id="content" class="card my-auto card2 col-6" style="height:92px;top:277px;">
 							<div class="card-text">
 								<h5 class='card-title'>Breakfast</h5>
 								<h6 class='card-subtitle small'>
@@ -298,7 +298,7 @@
 								</h6>
 							</div>
 						</div>
-						<div id="content" class="offset-6 card my-auto card3" style="width:50%;top:388px;">
+						<div id="content" class="offset-5 card my-auto card3 col-7" style="top:388px;">
 							<div class="card-text">
 								<h5 class='card-title'>Submissions Due</h5>
 								<h6 class='card-subtitle small'>
@@ -306,7 +306,7 @@
 								</h6>
 							</div>
 						</div>
-						<div id="content" class=" card my-auto card1" style="height:74px;width:50%;top:425px;">
+						<div id="content" class=" card my-auto card1 col-6" style="height:74px;top:425px;">
 							<div class="card-text">
 								<h5 class='card-title'>Demos</h5>
 								<h6 class='card-subtitle small'>
@@ -314,7 +314,7 @@
 								</h6>
 							</div>
 						</div>
-						<div id="content" class="offset-6 card my-auto card3" style="height:60px;width:50%;top:498px;">
+						<div id="content" class="offset-5 card my-auto card3 col-7" style="height:60px;top:498px;">
 							<div class="card-text">
 								<h5 class='card-title'>Lunch</h5>
 								<h6 class='card-subtitle small'>


### PR DESCRIPTION
The current schedule display is a little confusing with the two
columns, making users think the right hand side of Saturday seem like it
is for Sunday. This PR gives the right-hand column some overlap to make
it clear they are occurring at the same time.

@jhollowe mentioned this to me, so I made some quick changes to hopefully make it more readable.

Saturday example (Sunday was modified as well)
![image](https://user-images.githubusercontent.com/2939703/72955833-7ca1e080-3d6b-11ea-82e3-52adb0cc290c.png)
